### PR TITLE
fix(client/main): invalid `DrawText3D` and `string.format` calls

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -56,7 +56,7 @@ for i = 1, #config.locations do
             debug = config.polyDebug,
             inside = function()
                 if not lib.progressActive() then
-                    DrawText3D(string.format(Lang:t('wash_prompt', {value = price}), coords))
+                    DrawText3D(Lang:t('wash_prompt', {value = price}), coords)
                     if IsControlJustPressed(0, 38) then
                         if GetVehicleDirtLevel(cache.vehicle) > config.dirtLevel then
                             local netId = NetworkGetNetworkIdFromEntity(cache.vehicle)


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

Fixes invalid calls to `string.format` and `DrawText3D` that mess up the parameters.
`string.format` isn't of any use here and `coords` was supposed to be passed to `DrawText3D`.

Reported in the [Qbox Discord](https://canary.discord.com/channels/1012753553418354748/1031968831595352085/1198268531758878850).

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
