### PR TITLE
fix: validate car wash requests

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -45,7 +45,10 @@ for i = 1, #config.locations do
                 {
                     label = locale('wash_prompt', price),
                     icon = 'fas fa-car-on',
-                    serverEvent = 'qbx_carwash:server:startWash',
+                    onSelect = function()
+                        if not cache.vehicle then return end
+                        TriggerServerEvent('qbx_carwash:server:startWash', NetworkGetNetworkIdFromEntity(cache.vehicle))
+                    end,
                 },
             },
         })

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,16 +1,41 @@
 local price = require 'config.shared'.price
+local locations = require 'config.client'.locations
+local activeWashes = {}
+
+local function isNearCarWash(coords)
+    for i = 1, #locations do
+        if #(coords - locations[i]) <= 10.0 then return true end
+    end
+
+    return false
+end
 
 RegisterNetEvent('qbx_carwash:server:startWash', function(netId)
-    local player = exports.qbx_core:GetPlayer(source)
+    if type(netId) ~= 'number' or netId % 1 ~= 0 or activeWashes[source] then return end
 
-    if not player then return end
+    local src = source
+    local player = exports.qbx_core:GetPlayer(src)
+    local ped = GetPlayerPed(src)
+    local vehicle = NetworkGetEntityFromNetworkId(netId)
+    if not player or ped == 0 or vehicle == 0 or not DoesEntityExist(vehicle) or GetEntityType(vehicle) ~= 2 then return end
+    if GetVehiclePedIsIn(ped, false) ~= vehicle or not isNearCarWash(GetEntityCoords(ped)) then return end
 
+    local wash = {}
+    activeWashes[src] = wash
     if player.Functions.RemoveMoney('cash', price, locale('reason')) or player.Functions.RemoveMoney('bank', price, locale('reason')) then
         SetTimeout(6000, function()
-            SetVehicleDirtLevel(NetworkGetEntityFromNetworkId(netId), 0.0)
+            if DoesEntityExist(vehicle) and NetworkGetNetworkIdFromEntity(vehicle) == netId then
+                SetVehicleDirtLevel(vehicle, 0.0)
+            end
+            if activeWashes[src] == wash then activeWashes[src] = nil end
         end)
-        TriggerClientEvent('qbx_carwash:client:washCar', player.PlayerData.source)
+        TriggerClientEvent('qbx_carwash:client:washCar', src)
     else
-        exports.qbx_core:Notify(player.PlayerData.source, locale('no_money'), 'error')
+        activeWashes[src] = nil
+        exports.qbx_core:Notify(src, locale('no_money'), 'error')
     end
+end)
+
+AddEventHandler('playerDropped', function()
+    activeWashes[source] = nil
 end)


### PR DESCRIPTION
## What changed

- validate the network ID type and resolve it to an existing vehicle entity
- require the caller to be inside that exact vehicle at a configured car-wash location
- prevent overlapping wash/payment requests per player
- retain and revalidate the original entity/network-ID pairing before applying dirt changes
- pass the current vehicle explicitly from the target-mode interaction
- clear in-progress state safely on completion, failed payment, and disconnect

## Why

The server accepted any client-provided network ID, charged the caller, and invoked a vehicle native six seconds later without validating the entity, vehicle type, player relationship, or car-wash location. The delayed lookup could also resolve differently after entity deletion/reuse.

The wash is now bound to the validated caller, vehicle, location, and request lifecycle before payment is taken.

## Validation

- `git diff --check`
- direct Lua control-flow and syntax review (no Lua runtime/linter is installed locally)
- GitHub lint workflow will be monitored and every lint-report finding fixed